### PR TITLE
Add password validation for add account action

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A DSLink for Belimo Cloud API (v3).
 
 ### Versions
 
+* 1.4.0 - Change Add_Account action to verify username/password if account is already added.
 * 1.3.9 - Update User data (name, address etc) with each refresh every 5 minutes
 * 1.3.8 - Update DSLink SDK for fix with updating list subscriptions
 * 1.3.7 - Check for existing pending requests before adding a new one. Compare device, API and 

--- a/dslink.json
+++ b/dslink.json
@@ -1,6 +1,6 @@
 {
   "name" : "dslink-dart-belimo_cloud",
-  "version" : "1.3.9",
+  "version" : "1.4.0",
   "description" : "Belimo DSLink",
   "main" : "bin/run.dart",
   "engines" : {

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -181,14 +181,16 @@ class BClient {
 
     if (bd == null || bd['access_token'] == null) {
       logger.warning('Authorization: Status OK but no access_token available.' +
-        'body is: $bd');
+          'body is: $bd');
       _checkPass = null;
       return false;
     }
 
     _accessTok = bd['access_token'];
-    _pass = _checkPass;
-    _checkPass = null;
+    if (_checkPass != null) {
+      _pass = _checkPass;
+      _checkPass = null;
+    }
 
     return true;
   }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -64,10 +64,11 @@ class BClient {
   HttpClient _client;
   String user;
   String _pass;
+  String _checkPass;
   Uri _root;
   String _accessTok;
   int _queuedRequests = 0;
-  bool get _authed => _accessTok != null && _accessTok.isNotEmpty;
+  bool get authed => _accessTok != null && _accessTok.isNotEmpty;
 
   static Future<Map<String,dynamic>> _addDataRequest(DataRequest data) {
     var el = _requestCache[data.hashCode];
@@ -110,24 +111,38 @@ class BClient {
     };
   }
 
-  factory BClient(String username, String password) {
-    var cl = _cache[username] ??= new BClient._(username, password);
-    if (password != cl._pass) {
-      cl._pass = password;
-      cl._accessTok = null;
+  factory BClient(String user, String pass) {
+    var cl = _cache[user];
+
+    if (cl == null) {
+      cl = new BClient._(user, pass);
+      _cache[user] = cl;
+    } else {
+      cl._checkPass = pass;
     }
+
     return cl;
   }
 
   BClient._(this.user, this._pass) {
     _client = new HttpClient();
+    _client.badCertificateCallback = (X509Certificate cert, String host, int port) {
+      logger.warning('Invalid certificate received for: $host:$port');
+      return true;
+    };
     _root = Uri.parse(rootUrl);
   }
 
   /// Attempt to authenticate to remote cloud server with the credentials
   /// provided. Returns true on success and false on failure.
   Future<bool> authenticate() async {
-    if (_authed) return _authed;
+    // Already authenticated return true
+    if (authed && _checkPass == null) return authed;
+    // Already authenticated and password check shows same password return true
+    if (authed && _checkPass == _pass) {
+      _checkPass = null;
+      return authed;
+    }
 
     if (basicToken == null || basicToken.isEmpty) {
       throw new StateError('Required basic-token has not been supplied.');
@@ -137,6 +152,7 @@ class BClient {
 
     Map bd;
     HttpClientResponse resp;
+    String pw = _checkPass ?? _pass;
     try {
       var req = await _client.postUrl(uri);
       req.headers.set(_headerAuth, _basicAuth + basicToken);
@@ -144,12 +160,13 @@ class BClient {
           ContentType.parse('application/x-www-form-urlencoded');
       req.write('grant_type=password&' +
           'username=${Uri.encodeQueryComponent(user)}&' +
-          'password=${Uri.encodeQueryComponent(_pass)}');
+          'password=${Uri.encodeQueryComponent(pw)}');
 
       resp = await req.close();
       bd = await JSON.decode(await UTF8.decodeStream(resp));
     } catch (e) {
       logger.warning('Failed to decode response body', e);
+      return false;
     }
 
     if (resp.statusCode != HttpStatus.OK) {
@@ -158,15 +175,20 @@ class BClient {
         logger.warning('Error: ${bd['error']} '
             'Description: ${bd['error_description']}');
       }
+      _checkPass = null;
       return false;
     }
 
     if (bd == null || bd['access_token'] == null) {
       logger.warning('Authorization: Status OK but no access_token available.' +
         'body is: $bd');
+      _checkPass = null;
       return false;
     }
+
     _accessTok = bd['access_token'];
+    _pass = _checkPass;
+    _checkPass = null;
 
     return true;
   }

--- a/lib/src/nodes/accounts.dart
+++ b/lib/src/nodes/accounts.dart
@@ -87,7 +87,6 @@ class AddAccount extends SimpleNode {
       _link.save();
     } else {
       ret[_message] = 'Unable to authenticate with provided credentials';
-      cl.close();
     }
 
     return ret;
@@ -356,12 +355,12 @@ class AccountNode extends SimpleNode implements Account {
 
     var auth = await cl.authenticate();
     if (auth) {
+      // Only close old if the username is different
       if (curU != user) _client?.close();
+
       _client = cl;
       configs[_user] = user;
       configs[_pass] = pass;
-    } else {
-      cl.close();
     }
 
     return auth;

--- a/lib/src/nodes/accounts.dart
+++ b/lib/src/nodes/accounts.dart
@@ -69,10 +69,6 @@ class AddAccount extends SimpleNode {
 
     var n = NodeNamer.createName(name);
     var nd = provider.getNode('/$n');
-    if (nd != null) {
-      return ret..[_message] =
-          'Account with display name: "$name" already exists';
-    }
 
     var user = params[_user];
     var pass = params[_pass];
@@ -80,8 +76,12 @@ class AddAccount extends SimpleNode {
 
     ret[_success] = await cl.authenticate();
     if (ret[_success]) {
-
-      provider.addNode('/$n', AccountNode.definition(user, pass));
+      if (nd == null) {
+        provider.addNode('/$n', AccountNode.definition(user, pass));
+      } else {
+        (nd as AccountNode)..loadUser()
+            ..loadDevices();
+      }
 
       ret[_message] = 'Success!';
       _link.save();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dslink_belimo_cloud
 description: Belimo DSLink
 author: Matthew Butler <Matthew.Butler@AcuityBrands.com>
-version: 1.3.9
+version: 1.4.0
 environment:
     sdk: ">=1.13.0 <2.0.0"
 dependencies:


### PR DESCRIPTION
Previously we would wrongly assume new password should work or close.
We would not allow multiple authentications without throwing error (for instance if someone closed the window opened and logged back in they should be able to without needing to remove the account).

If account exists, check password as a second login attempt may not want to override the existing (invalid login attempt would break existing valid session)