### PR TITLE
Repopulate datanodes on new add if subscription exists

### DIFF
--- a/dslink.json
+++ b/dslink.json
@@ -1,6 +1,6 @@
 {
   "name" : "dslink-dart-belimo_cloud",
-  "version" : "1.5.4",
+  "version" : "1.5.5",
   "description" : "Belimo DSLink",
   "main" : "bin/run.dart",
   "engines" : {

--- a/lib/src/nodes/devices.dart
+++ b/lib/src/nodes/devices.dart
@@ -325,7 +325,9 @@ class DeviceNode extends ChildNode implements DeviceNd {
         return cl.getDeviceData(dev);
       }
       return null;
-    }).then(_loadData);
+    }).then((DeviceData data) {
+      _loadData(data, force: force);
+    });
 
     provider.updateValue('$path/$_devId', dev.id);
     provider.updateValue('$path/$_name', dev.name);
@@ -342,11 +344,11 @@ class DeviceNode extends ChildNode implements DeviceNd {
     provider.updateValue('$path/$_health/$_desc', dev.health.description);
   }
 
-  void _loadData(DeviceData data) {
+  void _loadData(DeviceData data, {bool force: false}) {
     _isRefreshing = false;
     if (data == null || data.values == null || data.values.isEmpty) return;
 
-    if (hasSubscription) {
+    if (hasSubscription && !force) {
       for (var dp in _datapoints) {
         var dv = provider.getNode('$path/$_data/$dp');
         if (dv == null) continue;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dslink_belimo_cloud
 description: Belimo DSLink
 author: Matthew Butler <Matthew.Butler@AcuityBrands.com>
-version: 1.5.4
+version: 1.5.5
 environment:
     sdk: ">=1.13.0 <2.0.0"
 dependencies:


### PR DESCRIPTION
Issues was caused because nodes had subscriptions but didn't exist yet so coulnd't
be found to be updated. Now add a "force" option when a device is first added to
ensure they are all added.